### PR TITLE
add visible cursor and fix panel resize issue

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,7 +16,14 @@ pub mod terminal;
 
 impl Widget for &App {
     fn render(self, area: ratatui::prelude::Rect, buf: &mut ratatui::prelude::Buffer) {
+        let _ = self.render_with_info(area, buf);
+    }
+}
 
+impl App {
+    /// Renders the app and returns terminal area and cursor visibility.
+    /// Returns: (terminal_area, should_show_cursor)
+    pub(crate) fn render_with_info(&self, area: Rect, buf: &mut Buffer) -> (Rect, bool) {
         // Split into three chunks: terminal, separator, assistant
         let chunks = Layout::default()
             .direction(Direction::Horizontal)
@@ -74,6 +81,11 @@ impl Widget for &App {
         if self.get_command_mode() {
             render_command_mode_hint(area, buf, cmdmode_color);
         }
+
+        // Determine if cursor should be shown
+        let should_show_cursor = matches!(active, ActivePane::Terminal) && !self.get_command_mode();
+        
+        (term_area, should_show_cursor)
     }
 }
 


### PR DESCRIPTION
## Add Cursor Display and Dynamic Terminal Resizing

### Summary
This PR implements two key UI improvements for the terminal panel:
1. Display and track cursor position in the terminal pane
2. Enable dynamic terminal resizing that adapts to window size changes

### Changes Made

#### 1. Cursor Display (`src/app.rs`, `src/ui/mod.rs`)
- Added cursor visibility management in the main draw loop
- Cursor is now visible when Terminal pane is active (hidden in Command Mode and Assistant pane)
- Cursor position is calculated relative to the terminal area offset and synced with the alacritty emulator
- Implemented `show_cursor()` and `hide_cursor()` calls based on active pane state

#### 2. Dynamic Terminal Resizing (`src/app.rs`)
- Added `last_terminal_size` field to track terminal dimensions
- Implemented automatic resize detection during each render cycle
- When terminal area size changes, both `TuiTerminal` and `ShellManager` PTY are resized simultaneously
- PTY resize ensures shell output adapts to new window dimensions

#### 3. Refactored Rendering Logic (`src/ui/mod.rs`)
- Extracted `render_with_info()` method that returns terminal area and cursor visibility flag
- This allows the main `draw()` method to access terminal area information outside the render closure
- Maintains separation of concerns while enabling post-render cursor positioning

### Technical Details
- Terminal resize is performed outside the `terminal.draw()` closure to comply with borrowing rules
- Cursor position is captured during rendering and applied after the frame is drawn
- The PTY is resized to match the terminal widget area, ensuring shell programs (like vim, htop) display correctly

### Testing
Tested scenarios:
- [x] Cursor displays and moves correctly during text input
- [x] Cursor hides when switching to Assistant pane (Ctrl+B → N)
- [x] Cursor hides when entering Command Mode (Ctrl+B)
- [x] Terminal output adapts when resizing the window
- [x] Shell programs handle resize events properly

