### PR TITLE
feat(ui): Implement visual mode in terminal and assistant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +62,26 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
 
 [[package]]
 name = "arrayvec"
@@ -154,6 +180,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytemuck"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +254,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +300,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -293,6 +349,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cursor-icon"
@@ -376,6 +438,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "eventsource-stream"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +510,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +554,16 @@ name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "flate2"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -565,6 +682,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.2",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +716,17 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -858,6 +996,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1179,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1207,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80986bbbcf925ebd3be54c26613d861255284584501595cf418320c078945608"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1091,6 +1263,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1164,6 +1409,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,6 +1488,21 @@ checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -1581,6 +1854,7 @@ version = "0.1.0"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
+ "arboard",
  "async-openai",
  "chrono",
  "crossterm",
@@ -1780,6 +2054,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,6 +2222,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -2430,6 +2724,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2697,6 +2997,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.2",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2797,4 +3114,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
 chrono = "0.4"
+arboard = "3"
 
 [lints.clippy]
 # Prevent silent failures - these are ERRORS, not warnings

--- a/src/ui/terminal.rs
+++ b/src/ui/terminal.rs
@@ -17,7 +17,10 @@ use ratatui::{
 use tokio::sync::mpsc::{Receiver, UnboundedSender};
 use tracing::error;
 
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+
 use crate::event::AppEvent;
+use super::visual::{VisualState, SelectionMode, PaneStatus, KeyHandleResult, copy_to_clipboard, is_in_selection_with_mode};
 
 /// Simple terminal size implementation that satisfies the alacritty Dimensions trait.
 #[derive(Debug, Copy, Clone)]
@@ -101,6 +104,10 @@ pub struct TuiTerminal {
     event_sink: UnboundedSender<AppEvent>,
     scroll_offset: usize,
     error_message: Option<String>,
+
+    // Visual mode state
+    visual_state: Option<VisualState>,
+
 }
 
 impl TuiTerminal {
@@ -125,6 +132,7 @@ impl TuiTerminal {
             event_sink,
             scroll_offset: 0,
             error_message: None,
+            visual_state: None,
         }
     }
 
@@ -208,6 +216,451 @@ impl TuiTerminal {
     /// Display an error message in the terminal.
     pub fn show_error(&mut self, message: &str) {
         self.error_message = Some(message.to_string());
+    }
+
+    // ========================================================================
+    // Visual Mode
+    // ========================================================================
+
+    /// Check if visual mode is active.
+    pub fn is_visual_mode(&self) -> bool {
+        self.visual_state.is_some()
+    }
+
+    /// Check if visual selection is active.
+    pub fn is_visual_selecting(&self) -> bool {
+        self.visual_state.as_ref().map_or(false, |s| s.is_selecting())
+    }
+
+    /// Get visual selection mode.
+    pub fn get_visual_selection_mode(&self) -> Option<SelectionMode> {
+        self.visual_state.as_ref().map(|s| s.get_selection_mode())
+    }
+
+    /// Get visual state reference.
+    pub fn visual_state(&self) -> Option<&VisualState> {
+        self.visual_state.as_ref()
+    }
+
+    /// Enter visual mode.
+    /// Initializes the cursor at the terminal's physical cursor position.
+    pub fn enter_visual_mode(&mut self) {
+        let grid = self.term.grid();
+        let history_size = grid.history_size();
+
+        // Get the terminal's physical cursor position
+        let cursor = grid.cursor.point;
+        // cursor.line is in screen coordinates (0 = top of screen, can be negative for history)
+        // Convert to content row (history_size + screen_row)
+        let screen_row = cursor.line.0.max(0) as usize;
+        let col = cursor.column.0 as usize;
+
+        // Content row = history_size + screen_row (when scroll_offset = 0)
+        // If we're scrolled, the physical cursor is still at the same content position
+        let content_row = history_size + screen_row;
+
+        self.visual_state = Some(VisualState::new(content_row, col));
+
+        // Auto-scroll to make sure the cursor is visible
+        self.scroll_to_visual_cursor();
+    }
+
+    /// Exit visual mode.
+    pub fn exit_visual_mode(&mut self) {
+        self.visual_state = None;
+    }
+
+    /// Move visual cursor by delta.
+    /// If cursor moves out of visible area, auto-scroll to keep it visible.
+    pub fn move_visual_cursor(&mut self, delta_row: i32, delta_col: i32) {
+        let Some(ref mut visual) = self.visual_state else {
+            return;
+        };
+
+        let grid = self.term.grid();
+        let history_size = grid.history_size();
+        let screen_lines = grid.screen_lines();
+        let columns = grid.columns();
+        let total_lines = history_size + screen_lines;
+
+        // Calculate max row and col
+        let max_row = total_lines.saturating_sub(1);
+        let max_col = columns.saturating_sub(1);
+
+        // Move cursor
+        visual.move_cursor(delta_row, delta_col, max_row, max_col);
+
+        // Auto-scroll to keep cursor in view
+        self.scroll_to_visual_cursor();
+    }
+
+    /// Scroll viewport to ensure visual cursor is visible.
+    fn scroll_to_visual_cursor(&mut self) {
+        let Some(ref visual) = self.visual_state else {
+            return;
+        };
+
+        let grid = self.term.grid();
+        let history_size = grid.history_size();
+        let screen_lines = grid.screen_lines();
+        let total_lines = history_size + screen_lines;
+
+        let (cursor_row, _) = visual.cursor;
+
+        // Calculate the visible range in content coordinates
+        // visible_top and visible_bottom are inclusive
+        let visible_bottom = total_lines.saturating_sub(1).saturating_sub(self.scroll_offset);
+        let visible_top = visible_bottom.saturating_sub(screen_lines.saturating_sub(1));
+
+        // Adjust scroll if cursor is out of visible range
+        if cursor_row < visible_top {
+            // Cursor is above visible area, scroll up
+            self.scroll_offset = total_lines.saturating_sub(1).saturating_sub(cursor_row).saturating_sub(screen_lines.saturating_sub(1));
+            self.scroll_offset = self.scroll_offset.min(history_size);
+        } else if cursor_row > visible_bottom {
+            // Cursor is below visible area, scroll down
+            self.scroll_offset = total_lines.saturating_sub(1).saturating_sub(cursor_row);
+        }
+    }
+
+    /// Cycle visual selection mode: None -> Line -> Block -> None
+    pub fn cycle_visual_selection(&mut self) {
+        if let Some(ref mut visual) = self.visual_state {
+            visual.cycle_selection_mode();
+        }
+    }
+
+    /// Clear visual selection (keep cursor position, reset to None mode).
+    pub fn clear_visual_selection(&mut self) {
+        if let Some(ref mut visual) = self.visual_state {
+            visual.clear_selection();
+        }
+    }
+
+    /// Copy selected text to clipboard and return true if successful.
+    /// Line mode: trims trailing spaces from each line.
+    /// Block mode: preserves all characters in the rectangle.
+    pub fn copy_visual_selection(&mut self) -> bool {
+        let Some(ref visual) = self.visual_state else {
+            return false;
+        };
+
+        let mode = visual.get_selection_mode();
+        let Some(((start_row, start_col), (end_row, end_col))) = visual.selection_range() else {
+            return false;
+        };
+
+        // Extract text from the terminal grid
+        let text = self.get_text_range(start_row, start_col, end_row, end_col, mode);
+        if text.is_empty() {
+            return false;
+        }
+
+        copy_to_clipboard(&text)
+    }
+
+    /// Get effective width of a line (position after last non-space character).
+    /// Returns 0 for empty lines.
+    fn get_line_effective_width(&self, content_row: usize) -> usize {
+        let grid = self.term.grid();
+        let history_size = grid.history_size();
+        let columns = grid.columns();
+
+        let grid_line_idx = content_row as i32 - history_size as i32;
+        let line = TermLine(grid_line_idx);
+
+        // Scan from right to find last non-space character
+        for col in (0..columns).rev() {
+            let cell = &grid[line][Column(col)];
+            if cell.c != ' ' && cell.c != '\0' {
+                return col + 1;
+            }
+        }
+        0 // Empty line
+    }
+
+    // ========================================================================
+    // Pane Status API (for App to query rendering info)
+    // ========================================================================
+
+    /// Get pane status for rendering title bar and hints.
+    /// This allows the component to control its appearance without exposing internal state.
+    pub fn get_pane_status(&self) -> PaneStatus {
+        let mut status_parts: Vec<String> = Vec::new();
+
+        if self.is_visual_mode() {
+            if let Some(mode) = self.get_visual_selection_mode() {
+                if let Some(name) = mode.display_name() {
+                    status_parts.push(name.to_string());
+                } else {
+                    status_parts.push("VISUAL".to_string());
+                }
+            } else {
+                status_parts.push("VISUAL".to_string());
+            }
+
+            // Show repeat count if being accumulated
+            if let Some(ref visual) = self.visual_state {
+                if let Some(count) = visual.get_repeat_count() {
+                    status_parts.push(format!("{}×", count));
+                }
+            }
+        }
+
+        if self.is_scrolled() {
+            status_parts.push(format!("Scrolled ↑{}", self.scroll_offset));
+        }
+
+        let title_status = if status_parts.is_empty() {
+            None
+        } else {
+            Some(status_parts.join(" "))
+        };
+
+        let hint_text = if self.is_visual_mode() {
+            Some(" ESC: Exit | Space: Select | y: Copy | hjkl: Move ")
+        } else {
+            None
+        };
+
+        let border_color = if self.is_visual_mode() {
+            Some(Color::Magenta)
+        } else {
+            None
+        };
+
+        PaneStatus {
+            title_status,
+            hint_text,
+            border_color,
+        }
+    }
+
+    /// Handle a key event when in visual mode.
+    /// Returns KeyHandleResult indicating how the key was processed.
+    pub fn handle_visual_key(&mut self, key: KeyEvent) -> KeyHandleResult {
+        if !matches!(key.kind, KeyEventKind::Press) {
+            return KeyHandleResult::NotConsumed;
+        }
+
+        // If not in visual mode, don't consume
+        let Some(ref mut visual) = self.visual_state else {
+            return KeyHandleResult::NotConsumed;
+        };
+
+        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+
+        // Ctrl+B => Request command mode
+        if ctrl && matches!(key.code, KeyCode::Char('b') | KeyCode::Char('B')) {
+            visual.clear_repeat_count();
+            return KeyHandleResult::RequestCommandMode;
+        }
+
+        match key.code {
+            // Digit keys for repeat count
+            KeyCode::Char(c @ '1'..='9') => {
+                let digit = c.to_digit(10).unwrap_or(0) as usize;
+                visual.accumulate_repeat_digit(digit);
+                return KeyHandleResult::Consumed;
+            }
+            KeyCode::Char('0') if visual.has_repeat_count() => {
+                visual.accumulate_repeat_digit(0);
+                return KeyHandleResult::Consumed;
+            }
+
+            // Escape => if in selection mode, go back to VISUAL; if in VISUAL, exit
+            KeyCode::Esc => {
+                if visual.is_selecting() {
+                    // In Line/Block mode, go back to None (VISUAL) mode
+                    visual.clear_selection();
+                } else {
+                    // Already in None mode, exit visual mode
+                    self.visual_state = None;
+                }
+            }
+
+            // Space => toggle selection mode: None -> Line, then Line <-> Block
+            KeyCode::Char(' ') => {
+                visual.cycle_selection_mode();
+            }
+
+            // y => copy selected text and clear selection
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                let _ = self.copy_visual_selection();
+                if let Some(ref mut v) = self.visual_state {
+                    v.clear_selection();
+                }
+            }
+
+            // Scroll keys (Shift + arrows) - scroll without moving cursor
+            KeyCode::Up if shift => {
+                let repeat = visual.take_repeat_count();
+                self.scroll_up(repeat);
+            }
+            KeyCode::Down if shift => {
+                let repeat = visual.take_repeat_count();
+                self.scroll_down(repeat);
+            }
+            KeyCode::PageUp => {
+                let repeat = visual.take_repeat_count();
+                self.scroll_up(repeat * 10);
+            }
+            KeyCode::PageDown => {
+                let repeat = visual.take_repeat_count();
+                self.scroll_down(repeat * 10);
+            }
+
+            // Cursor movement keys (hjkl and arrows)
+            KeyCode::Left | KeyCode::Char('h') | KeyCode::Char('H') => {
+                let repeat = visual.take_repeat_count();
+                for _ in 0..repeat {
+                    self.move_visual_cursor(0, -1);
+                }
+            }
+            KeyCode::Right | KeyCode::Char('l') => {
+                let repeat = visual.take_repeat_count();
+                for _ in 0..repeat {
+                    self.move_visual_cursor(0, 1);
+                }
+            }
+            KeyCode::Up | KeyCode::Char('k') | KeyCode::Char('K') => {
+                let repeat = visual.take_repeat_count();
+                for _ in 0..repeat {
+                    self.move_visual_cursor(-1, 0);
+                }
+            }
+            KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('J') => {
+                let repeat = visual.take_repeat_count();
+                for _ in 0..repeat {
+                    self.move_visual_cursor(1, 0);
+                }
+            }
+
+            _ => {
+                // Unknown key in visual mode - clear repeat count but consume
+                if let Some(ref mut v) = self.visual_state {
+                    v.clear_repeat_count();
+                }
+            }
+        }
+
+        KeyHandleResult::Consumed
+    }
+
+    /// Get text from a range in content coordinates.
+    /// Get text from a range in content coordinates.
+    /// Line mode: trims trailing spaces from each line, adjusts col range per line.
+    /// Block mode: extracts exact rectangle, preserves spaces.
+    fn get_text_range(&self, start_row: usize, start_col: usize, end_row: usize, end_col: usize, mode: SelectionMode) -> String {
+        let grid = self.term.grid();
+        let history_size = grid.history_size();
+        let columns = grid.columns();
+
+        let mut result = String::new();
+
+        for row in start_row..=end_row {
+            // Convert content row to grid line index
+            let grid_line_idx = row as i32 - history_size as i32;
+            let line = TermLine(grid_line_idx);
+
+            // Get effective line width for Line mode clamping
+            let line_width = self.get_line_effective_width(row);
+
+            // Determine column range based on mode
+            let (col_start, col_end) = match mode {
+                SelectionMode::None => continue,
+                SelectionMode::Line => {
+                    // Line mode: clamp to effective line width
+                    if line_width == 0 {
+                        // Empty line, skip content but keep newline
+                        if row < end_row {
+                            result.push('\n');
+                        }
+                        continue;
+                    }
+                    let cs = if row == start_row { start_col.min(line_width.saturating_sub(1)) } else { 0 };
+                    let ce = if row == end_row {
+                        end_col.min(line_width.saturating_sub(1))
+                    } else {
+                        line_width.saturating_sub(1)
+                    };
+                    (cs, ce)
+                }
+                SelectionMode::Block => {
+                    // Block mode: use exact rectangle columns
+                    (start_col, end_col.min(columns.saturating_sub(1)))
+                }
+            };
+
+            // Extract characters from this line
+            let mut line_text = String::new();
+            for col in col_start..=col_end {
+                if col >= columns {
+                    break;
+                }
+                let cell = &grid[line][Column(col)];
+
+                // Skip wide character spacers
+                if cell.flags.contains(alacritty_terminal::term::cell::Flags::WIDE_CHAR_SPACER) {
+                    continue;
+                }
+
+                line_text.push(cell.c);
+            }
+
+            // For Line mode, trim trailing whitespace
+            // For Block mode, preserve as-is
+            let final_text = match mode {
+                SelectionMode::Line => line_text.trim_end().to_string(),
+                SelectionMode::Block | SelectionMode::None => line_text,
+            };
+            result.push_str(&final_text);
+
+            // Add newline between lines (but not after the last line)
+            if row < end_row {
+                result.push('\n');
+            }
+        }
+
+        result
+    }
+
+    /// Get visual cursor position in screen coordinates (for rendering).
+    /// Returns (screen_row, screen_col) if cursor is visible, None otherwise.
+    pub fn get_visual_cursor_screen_pos(&self) -> Option<(usize, usize)> {
+        let visual = self.visual_state.as_ref()?;
+        let (cursor_row, cursor_col) = visual.cursor;
+
+        let grid = self.term.grid();
+        let history_size = grid.history_size();
+        let screen_lines = grid.screen_lines();
+        let total_lines = history_size + screen_lines;
+
+        // Calculate visible range
+        let visible_bottom = total_lines.saturating_sub(1).saturating_sub(self.scroll_offset);
+        let visible_top = visible_bottom.saturating_sub(screen_lines.saturating_sub(1));
+
+        // Check if cursor is in visible range
+        if cursor_row >= visible_top && cursor_row <= visible_bottom {
+            let screen_row = cursor_row - visible_top;
+            Some((screen_row, cursor_col))
+        } else {
+            None
+        }
+    }
+
+    /// Convert screen position to content row for selection checking.
+    fn screen_row_to_content_row(&self, screen_row: usize) -> usize {
+        let grid = self.term.grid();
+        let history_size = grid.history_size();
+        let screen_lines = grid.screen_lines();
+        let total_lines = history_size + screen_lines;
+
+        let visible_bottom = total_lines.saturating_sub(1).saturating_sub(self.scroll_offset);
+        let visible_top = visible_bottom.saturating_sub(screen_lines.saturating_sub(1));
+
+        visible_top + screen_row
     }
 
     /// Get rendered lines for display.
@@ -328,6 +781,11 @@ impl Widget for &TuiTerminal {
 
         let lines = self.get_lines();
 
+        // Get visual mode state for highlighting
+        let visual_cursor_pos = self.get_visual_cursor_screen_pos();
+        let selection_range = self.visual_state.as_ref().and_then(|v| v.selection_range());
+        let selection_mode = self.visual_state.as_ref().map(|v| v.get_selection_mode()).unwrap_or(SelectionMode::None);
+
         // Render lines directly to buffer
         for (row, line) in lines.iter().enumerate() {
             if row >= area.height as usize {
@@ -335,6 +793,8 @@ impl Widget for &TuiTerminal {
             }
 
             let mut x = area.x;
+            let mut col: usize = 0;
+
             for span in &line.spans {
                 let content = &span.content;
                 for c in content.chars() {
@@ -347,10 +807,52 @@ impl Widget for &TuiTerminal {
                     // the position where tab was, subsequent characters are already at
                     // correct positions.
                     let render_char = if c == '\t' { ' ' } else { c };
+
+                    // Determine style with visual mode modifications
+                    let mut style = span.style;
+
+                    // Check if this cell is the visual cursor
+                    let is_cursor = visual_cursor_pos.map_or(false, |(cr, cc)| cr == row && cc == col);
+
+                    // Check if this cell is in the selection range
+                    let is_selected = selection_range.map_or(false, |(start, end)| {
+                        let content_row = self.screen_row_to_content_row(row);
+                        is_in_selection_with_mode(
+                            content_row,
+                            col,
+                            start,
+                            end,
+                            selection_mode,
+                            |r| self.get_line_effective_width(r),
+                        )
+                    });
+
+                    if is_cursor {
+                        // Visual cursor: blue background, white foreground
+                        style = Style::default().fg(Color::White).bg(Color::Blue);
+                    } else if is_selected {
+                        // Selection: blue background, white foreground
+                        style = Style::default().fg(Color::White).bg(Color::Blue);
+                    }
+
                     if let Some(cell) = buf.cell_mut((x, area.y + row as u16)) {
-                        cell.set_char(render_char).set_style(span.style);
+                        cell.set_char(render_char).set_style(style);
                     }
                     x += 1;
+                    col += 1;
+                }
+            }
+
+            // If cursor is on this row but beyond the rendered content, render it
+            if let Some((cursor_row, cursor_col)) = visual_cursor_pos {
+                if cursor_row == row && cursor_col >= col {
+                    let cursor_x = area.x + cursor_col as u16;
+                    if cursor_x < area.x + area.width {
+                        let style = Style::default().fg(Color::White).bg(Color::Blue);
+                        if let Some(cell) = buf.cell_mut((cursor_x, area.y + row as u16)) {
+                            cell.set_char(' ').set_style(style);
+                        }
+                    }
                 }
             }
         }

--- a/src/ui/visual.rs
+++ b/src/ui/visual.rs
@@ -1,0 +1,346 @@
+//! Visual mode state management for text selection and copying.
+//!
+//! This module provides shared data structures for Visual mode functionality
+//! in both Terminal and Assistant panes.
+
+use arboard::Clipboard;
+use ratatui::style::Color;
+use tracing::error;
+
+// ============================================================================
+// Pane Status API (for rendering title bar and hints)
+// ============================================================================
+
+/// Status information that a pane provides for rendering.
+/// This allows components to control their title and hints without
+/// exposing internal state details to App.
+#[derive(Debug, Clone, Default)]
+pub struct PaneStatus {
+    /// Status text to show in title bar (e.g., "VISUAL | Scrolled ↑5")
+    pub title_status: Option<String>,
+    /// Hint text for the bottom bar
+    pub hint_text: Option<&'static str>,
+    /// Override border color (None = use default based on active state)
+    pub border_color: Option<Color>,
+}
+
+impl PaneStatus {
+    pub fn normal() -> Self {
+        Self::default()
+    }
+
+    pub fn with_status(mut self, status: impl Into<String>) -> Self {
+        self.title_status = Some(status.into());
+        self
+    }
+
+    pub fn with_hint(mut self, hint: &'static str) -> Self {
+        self.hint_text = Some(hint);
+        self
+    }
+
+    pub fn with_color(mut self, color: Color) -> Self {
+        self.border_color = Some(color);
+        self
+    }
+}
+
+/// Result of handling a key event in a component.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyHandleResult {
+    /// Key was consumed by the component
+    Consumed,
+    /// Key was not handled, App should process it
+    NotConsumed,
+    /// Request to enter command mode (Ctrl+B in visual mode)
+    RequestCommandMode,
+}
+
+/// Selection mode in visual mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SelectionMode {
+    /// No selection, just cursor movement (VISUAL)
+    #[default]
+    None,
+    /// Line-based selection from anchor to cursor (VISUAL SELECT)
+    /// Selection is clamped to each line's effective width (no trailing spaces)
+    Line,
+    /// Block/rectangle selection (VISUAL BLOCK)
+    /// Selection is the rectangle formed by anchor and cursor, as-is
+    Block,
+}
+
+impl SelectionMode {
+    /// Toggle between Line and Block modes (for use when already in selection)
+    pub fn toggle_line_block(self) -> Self {
+        match self {
+            SelectionMode::None => SelectionMode::Line, // First time entering selection
+            SelectionMode::Line => SelectionMode::Block,
+            SelectionMode::Block => SelectionMode::Line,
+        }
+    }
+
+    /// Get display name for status bar
+    pub fn display_name(&self) -> Option<&'static str> {
+        match self {
+            SelectionMode::None => None,
+            SelectionMode::Line => Some("VISUAL SELECT"),
+            SelectionMode::Block => Some("VISUAL BLOCK"),
+        }
+    }
+}
+
+/// Visual mode cursor and selection state.
+///
+/// This struct tracks:
+/// - The current cursor position (row, col)
+/// - The selection anchor point and mode
+/// - Vim-style repeat count (e.g., "5j" moves down 5 lines)
+#[derive(Debug, Clone, Default)]
+pub struct VisualState {
+    /// Current cursor position (row, col) in the content coordinate system.
+    /// Row 0 is the first line of content (may be in scrollback history).
+    pub cursor: (usize, usize),
+
+    /// Selection anchor point. When set, text between anchor and cursor is selected.
+    /// The meaning depends on selection_mode.
+    pub anchor: Option<(usize, usize)>,
+
+    /// Current selection mode (None, Line, Block)
+    pub selection_mode: SelectionMode,
+
+    /// Vim-style repeat count for commands (e.g., "5j" = move down 5 lines).
+    repeat_count: Option<usize>,
+}
+
+impl VisualState {
+    /// Create a new VisualState with cursor at the given position.
+    pub fn new(row: usize, col: usize) -> Self {
+        Self {
+            cursor: (row, col),
+            anchor: None,
+            selection_mode: SelectionMode::None,
+            repeat_count: None,
+        }
+    }
+
+    /// Get and consume the repeat count (returns 1 if not set).
+    pub fn take_repeat_count(&mut self) -> usize {
+        self.repeat_count.take().unwrap_or(1)
+    }
+
+    /// Accumulate a digit to the repeat count.
+    pub fn accumulate_repeat_digit(&mut self, digit: usize) {
+        let current = self.repeat_count.unwrap_or(0);
+        // Limit to reasonable max to prevent overflow
+        let new_count = current.saturating_mul(10).saturating_add(digit).min(9999);
+        self.repeat_count = Some(new_count);
+    }
+
+    /// Check if repeat count is being accumulated.
+    pub fn has_repeat_count(&self) -> bool {
+        self.repeat_count.is_some()
+    }
+
+    /// Get current repeat count value (for display purposes).
+    pub fn get_repeat_count(&self) -> Option<usize> {
+        self.repeat_count
+    }
+
+    /// Clear repeat count without consuming.
+    pub fn clear_repeat_count(&mut self) {
+        self.repeat_count = None;
+    }
+
+    /// Check if selection mode is active (not None).
+    pub fn is_selecting(&self) -> bool {
+        self.selection_mode != SelectionMode::None
+    }
+
+    /// Get current selection mode.
+    pub fn get_selection_mode(&self) -> SelectionMode {
+        self.selection_mode
+    }
+
+    /// Toggle selection mode:
+    /// - None -> Line (enter selection, set anchor)
+    /// - Line <-> Block (toggle between selection types, keep anchor)
+    pub fn cycle_selection_mode(&mut self) {
+        let was_selecting = self.is_selecting();
+        self.selection_mode = self.selection_mode.toggle_line_block();
+
+        // Set anchor only when first entering selection mode
+        if !was_selecting && self.anchor.is_none() {
+            // Entering selection mode, set anchor at current position
+            self.anchor = Some(self.cursor);
+        }
+        // If already has anchor (cycling Line -> Block), keep it
+    }
+
+    /// Get the selection range as (start, end) where start <= end.
+    /// Returns None if not in selection mode.
+    /// For Line mode: start and end define the text flow range.
+    /// For Block mode: start is top-left, end is bottom-right of rectangle.
+    pub fn selection_range(&self) -> Option<((usize, usize), (usize, usize))> {
+        if self.selection_mode == SelectionMode::None {
+            return None;
+        }
+
+        self.anchor.map(|anchor| {
+            let (ar, ac) = anchor;
+            let (cr, cc) = self.cursor;
+
+            match self.selection_mode {
+                SelectionMode::None => unreachable!(),
+                SelectionMode::Line => {
+                    // Line mode: order by row first, then column
+                    if ar < cr || (ar == cr && ac <= cc) {
+                        ((ar, ac), (cr, cc))
+                    } else {
+                        ((cr, cc), (ar, ac))
+                    }
+                }
+                SelectionMode::Block => {
+                    // Block mode: top-left to bottom-right rectangle
+                    let min_row = ar.min(cr);
+                    let max_row = ar.max(cr);
+                    let min_col = ac.min(cc);
+                    let max_col = ac.max(cc);
+                    ((min_row, min_col), (max_row, max_col))
+                }
+            }
+        })
+    }
+
+    /// Move cursor by delta, clamping to valid range.
+    /// Returns true if the cursor actually moved.
+    pub fn move_cursor(&mut self, delta_row: i32, delta_col: i32, max_row: usize, max_col: usize) -> bool {
+        let old_cursor = self.cursor;
+
+        let new_row = (self.cursor.0 as i32 + delta_row).clamp(0, max_row as i32) as usize;
+        let new_col = (self.cursor.1 as i32 + delta_col).clamp(0, max_col as i32) as usize;
+
+        self.cursor = (new_row, new_col);
+        self.cursor != old_cursor
+    }
+
+    /// Set cursor to a specific position.
+    pub fn set_cursor(&mut self, row: usize, col: usize) {
+        self.cursor = (row, col);
+    }
+
+    /// Clear selection (reset to None mode).
+    pub fn clear_selection(&mut self) {
+        self.anchor = None;
+        self.selection_mode = SelectionMode::None;
+    }
+}
+
+/// Copy text to system clipboard.
+/// Returns true if successful.
+pub fn copy_to_clipboard(text: &str) -> bool {
+    match Clipboard::new() {
+        Ok(mut clipboard) => {
+            match clipboard.set_text(text) {
+                Ok(()) => true,
+                Err(e) => {
+                    error!("Failed to copy to clipboard: {}", e);
+                    false
+                }
+            }
+        }
+        Err(e) => {
+            error!("Failed to access clipboard: {}", e);
+            false
+        }
+    }
+}
+
+/// Check if a position is within a LINE selection range.
+/// This is for text-flow selection where each line from start to end is included.
+pub fn is_in_line_selection(row: usize, col: usize, start: (usize, usize), end: (usize, usize)) -> bool {
+    let (sr, sc) = start;
+    let (er, ec) = end;
+
+    if row < sr || row > er {
+        return false;
+    }
+
+    if row == sr && row == er {
+        // Single line selection
+        col >= sc && col <= ec
+    } else if row == sr {
+        // First line of multi-line selection
+        col >= sc
+    } else if row == er {
+        // Last line of multi-line selection
+        col <= ec
+    } else {
+        // Middle line of multi-line selection
+        true
+    }
+}
+
+/// Check if a position is within a BLOCK (rectangle) selection range.
+/// This is for rectangle selection where all cells in the rectangle are included.
+pub fn is_in_block_selection(row: usize, col: usize, start: (usize, usize), end: (usize, usize)) -> bool {
+    let (sr, sc) = start;
+    let (er, ec) = end;
+
+    row >= sr && row <= er && col >= sc && col <= ec
+}
+
+/// Check if a position is within a selection range, given the selection mode.
+/// For Line mode, optionally clamps to effective line width.
+/// `line_width_fn` returns the effective width (last non-space char + 1) for a given row.
+pub fn is_in_selection_with_mode<F>(
+    row: usize,
+    col: usize,
+    start: (usize, usize),
+    end: (usize, usize),
+    mode: SelectionMode,
+    line_width_fn: F,
+) -> bool
+where
+    F: Fn(usize) -> usize,
+{
+    match mode {
+        SelectionMode::None => false,
+        SelectionMode::Line => {
+            // Clamp column to effective line width
+            let line_width = line_width_fn(row);
+            if col >= line_width {
+                return false;
+            }
+
+            let (sr, sc) = start;
+            let (er, ec) = end;
+
+            if row < sr || row > er {
+                return false;
+            }
+
+            if row == sr && row == er {
+                // Single line: clamp both start and end
+                let eff_sc = sc.min(line_width.saturating_sub(1));
+                let eff_ec = ec.min(line_width.saturating_sub(1));
+                col >= eff_sc && col <= eff_ec
+            } else if row == sr {
+                // First line: clamp start col
+                let eff_sc = sc.min(line_width.saturating_sub(1));
+                col >= eff_sc
+            } else if row == er {
+                // Last line: clamp end col
+                let eff_ec = ec.min(line_width.saturating_sub(1));
+                col <= eff_ec
+            } else {
+                // Middle line: all columns up to line width
+                true
+            }
+        }
+        SelectionMode::Block => {
+            // Block mode: don't clamp, use raw rectangle
+            is_in_block_selection(row, col, start, end)
+        }
+    }
+}


### PR DESCRIPTION
- Added visual mode functionality to both `TuiTerminal` and `TuiAssistant`, allowing users to enter visual mode, select text, and copy selections to the clipboard.
- Enhanced key event handling to support visual mode commands, including cursor movement and selection toggling.
- Updated UI rendering to highlight visual selections and the visual cursor in both terminal and assistant panes.
- Improved pane status display to reflect visual mode state and provide relevant hints to users.
- Refactored related components to ensure seamless integration of visual mode features across the application.